### PR TITLE
added subscription filter property check

### DIFF
--- a/src/serverless_plugin_subscription_filter.js
+++ b/src/serverless_plugin_subscription_filter.js
@@ -108,7 +108,12 @@ class ServerlessPluginSubscriptionFilter {
 
       return functionObj.events;
     }).map(event =>
-      event.subscriptionFilter.logGroupName,
+      {
+        //Make sure the subscription filter actually exists
+        if (event.subscriptionFilter){
+          return event.subscriptionFilter.logGroupName;
+        }
+      }
     );
 
     _.mapKeys(_.countBy(logGroupNames), (value, key) => {


### PR DESCRIPTION
I was running into errors with the plugin when multiple functions were defined in my serverless.yml if they did not all have a subscription filter defined. I made a quick fix to the code I have and figured I would see if you wanted to merge it for others. I also created an issue so others in the same situation know this is being looked at or has been fixed.