### PR TITLE
Fix "Cannot read property 'logGroupName' of undefined" error when multiple functions are defined

### DIFF
--- a/src/serverless_plugin_subscription_filter.js
+++ b/src/serverless_plugin_subscription_filter.js
@@ -107,9 +107,8 @@ class ServerlessPluginSubscriptionFilter {
       const functionObj = this.serverless.service.getFunction(functionName);
 
       return functionObj.events;
-    }).map(event =>
-      event.subscriptionFilter.logGroupName,
-    );
+    }).filter(event => event.subscriptionFilter)
+      .map(event => event.subscriptionFilter.logGroupName);
 
     _.mapKeys(_.countBy(logGroupNames), (value, key) => {
       if (value > 1) {


### PR DESCRIPTION
fixes https://github.com/tsub/serverless-plugin-subscription-filter/issues/9